### PR TITLE
Adding support for a configurable environment (defaults to 1a5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An API client is included in this package
 ```js
 const Rancher = require('rancher-node');
 
-const client = new Rancher.Client({ host: '127.0.0.1', port: 8080, access_key: 'SoMeToKeN', secret_key: 'someSecRetToken' });
+const client = new Rancher.Client({ host: '127.0.0.1', port: 8080, access_key: 'SoMeToKeN', secret_key: 'someSecRetToken', environment: '1a5' });
 
 client.getContainer(containerId).then((container) => {
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,7 +8,8 @@ internals.schema = Joi.object({
     host: Joi.string().required(),
     port: Joi.number().required(),
     access_key: Joi.string().required(),
-    secret_key: Joi.string().required()
+    secret_key: Joi.string().required(),
+    environment: Joi.string()
 });
 
 class RancherClient {
@@ -52,105 +53,108 @@ class RancherClient {
                 });
             });
         };
+
+        this.environmentId = config.environment || '1a5';
+        
     };
 
     createContainer(container) {
-        return this._request('post', '/v2-beta/projects/1a5/container', { payload: JSON.stringify(container) });
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/container`, { payload: JSON.stringify(container) });
     };
 
     getContainer(containerId) {
 
         Joi.assert(containerId, Joi.string().required(), 'Must specify container id');
-        return this._request('get', `/v2-beta/projects/1a5/container/${containerId}`);
+        return this._request('get', `/v2-beta/projects/${this.environmentId}/container/${containerId}`);
     }
 
     updateContainer(container) {
-        return this._request('post', `/v2-beta/projects/1a5/container/${container.id}`, { payload: JSON.stringify(container) });
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/container/${container.id}`, { payload: JSON.stringify(container) });
     }
 
     stopContainer(containerId, stopParams) {
         Joi.assert(containerId, Joi.string().required(), 'Must specify container id');
-        return this._request('post', `/v2-beta/projects/1a5/container/${containerId}/?action=stop`, { payload: JSON.stringify(stopParams) });
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/container/${containerId}/?action=stop`, { payload: JSON.stringify(stopParams) });
     }
 
     startContainer(containerId) {
         Joi.assert(containerId, Joi.string().required(), 'Must specify container id');
-        return this._request('post', `/v2-beta/projects/1a5/container/${containerId}/?action=start`);
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/container/${containerId}/?action=start`);
     }
 
     restartContainer(containerId) {
         Joi.assert(containerId, Joi.string().required(), 'Must specify container id');
-        return this._request('post', `/v2-beta/projects/1a5/container/${containerId}/?action=restart`);
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/container/${containerId}/?action=restart`);
     }
 
     removeContainer(containerId) {
         Joi.assert(containerId, Joi.string().required(), 'Must specify container id');
-        return this._request('delete', `/v2-beta/projects/1a5/container/${containerId}`);
+        return this._request('delete', `/v2-beta/projects/${this.environmentId}/container/${containerId}`);
     }
 
     purgeContainer(containerId) {
         Joi.assert(containerId, Joi.string().required(), 'Must specify container id');
-        return this._request('post', `/v2-beta/projects/1a5/container/${containerId}/?action=purge`);
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/container/${containerId}/?action=purge`);
     }
 
     getContainerLogs(containerId) {
         Joi.assert(containerId, Joi.string().required(), 'Must specify container id');
-        return this._request('post', `/v2-beta/projects/1a5/container/${containerId}/?action=logs`);
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/container/${containerId}/?action=logs`);
     }
 
     createStack(stack) {
-        return this._request('post', '/v2-beta/projects/1a5/stack', { payload: JSON.stringify(stack) });
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/stack`, { payload: JSON.stringify(stack) });
     }
 
     getStack(stackId) {
 
         Joi.assert(stackId, Joi.string().required(), 'Must specify stack id');
-        return this._request('get', `/v2-beta/projects/1a5/stack/${stackId}`);
+        return this._request('get', `/v2-beta/projects/${this.environmentId}/stack/${stackId}`);
     }
 
     getStackServices(stackId) {
 
         Joi.assert(stackId, Joi.string().required(), 'Must specify stack id');
-        return this._request('get', `/v2-beta/projects/1a5/stack/${stackId}/services`);
+        return this._request('get', `/v2-beta/projects/${this.environmentId}/stack/${stackId}/services`);
     }
 
     removeStack(stackId) {
 
         Joi.assert(stackId, Joi.string().required(), 'Must specify stack id');
-        return this._request('post', `/v2-beta/projects/1a5/stack/${stackId}/?action=remove`);
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/stack/${stackId}/?action=remove`);
     }
 
     getPorts() {
-        return this._request('get', `/v2-beta/projects/1a5/ports`);
+        return this._request('get', `/v2-beta/projects/${this.environmentId}/ports`);
     }
 
     getHosts() {
-        return this._request('get', `/v2-beta/projects/1a5/hosts`);
+        return this._request('get', `/v2-beta/projects/${this.environmentId}/hosts`);
     }
 
     getHost(hostId) {
-        return this._request('get', `/v2-beta/projects/1a5/hosts/${hostId}`);
+        return this._request('get', `/v2-beta/projects/${this.environmentId}/hosts/${hostId}`);
     }
 
     getService(serviceId) {
 
         Joi.assert(serviceId, Joi.string().required(), 'Must specify service id');
-        return this._request('get', `/v2-beta/projects/1a5/services/${serviceId}`);
+        return this._request('get', `/v2-beta/projects/${this.environmentId}/services/${serviceId}`);
     }
 
     stopService(serviceId) {
         Joi.assert(serviceId, Joi.string().required(), 'Must specify service id');
-        return this._request('post', `/v2-beta/projects/1a5/services/${serviceId}/?action=deactivate`);
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/services/${serviceId}/?action=deactivate`);
     }
 
     startService(serviceId) {
         Joi.assert(serviceId, Joi.string().required(), 'Must specify service id');
-        return this._request('post', `/v2-beta/projects/1a5/services/${serviceId}/?action=activate`);
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/services/${serviceId}/?action=activate`);
     }
 
     restartService(serviceId, restartParams) {
         Joi.assert(serviceId, Joi.string().required(), 'Must specify service id');
-        return this._request('post', `/v2-beta/projects/1a5/services/${serviceId}/?action=restart`, { payload: JSON.stringify(restartParams) });
+        return this._request('post', `/v2-beta/projects/${this.environmentId}/services/${serviceId}/?action=restart`, { payload: JSON.stringify(restartParams) });
     }
 };
 


### PR DESCRIPTION
I needed to change the environment in the url of the GET requests. Tested and works great for me, would love to see it in the official NPM package.